### PR TITLE
wave3: increase limits.cpu

### DIFF
--- a/deployment/kubernetes/wave3.yaml.envsubst
+++ b/deployment/kubernetes/wave3.yaml.envsubst
@@ -44,7 +44,7 @@ items:
               resources:
                 limits:
                   memory: 1Gi
-                  cpu: 100m
+                  cpu: 1.0
                 requests:
                   memory: 75Mi
                   cpu: 40m


### PR DESCRIPTION
- from `100m` to `1.0`
  - based on recommendation from Evan in #releng

ref: REL-1074
