### PR TITLE
chore: increase cpu limits

### DIFF
--- a/deployment/kubernetes/wave3.yaml.envsubst
+++ b/deployment/kubernetes/wave3.yaml.envsubst
@@ -44,7 +44,7 @@ items:
               resources:
                 limits:
                   memory: 2Gi
-                  cpu: '1'
+                  cpu: '2'
                 requests:
                   memory: 2Gi
                   cpu: '1'

--- a/deployment/kubernetes/wave4.yaml.envsubst
+++ b/deployment/kubernetes/wave4.yaml.envsubst
@@ -44,7 +44,7 @@ items:
               resources:
                 limits:
                   memory: 2Gi
-                  cpu: '1'
+                  cpu: '2'
                 requests:
                   memory: 2Gi
                   cpu: '1'

--- a/deployment/kubernetes/wave5.yaml.envsubst
+++ b/deployment/kubernetes/wave5.yaml.envsubst
@@ -44,7 +44,7 @@ items:
               resources:
                 limits:
                   memory: 2Gi
-                  cpu: '1'
+                  cpu: '2'
                 requests:
                   memory: 2Gi
                   cpu: '1'


### PR DESCRIPTION
Even the smallest envs - even dev - are using >1 cpu during the execution cycle.
For the production envs, increase the limit to prevent issues. US-South is
currently locked to have this increase applied manually
